### PR TITLE
[FIX] Fixed kanji to romaji bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,16 @@ class Card {
       return wanakana.toRomaji(hiraganaPart.join('')).toUpperCase();
     });
 
-    return romajiParts.join('').slice(0, -1);
+    if (romajiParts[romajiParts.length - 1] === '.') {
+      romajiParts[romajiParts.length - 1] = '';
+    }
+
+    let rmj = romajiParts.join('');
+    if (rmj[rmj.length - 1] === '•') {
+      rmj = rmj.slice(0, -1);
+    }
+
+    return rmj;
   }
 }
 
@@ -252,7 +261,17 @@ function App() {
       return wanakana.toRomaji(hiraganaPart.join('')).toUpperCase();
     });
 
-    return romajiParts.join('').slice(0, -1);
+    if (romajiParts[romajiParts.length - 1] === '.') {
+      romajiParts[romajiParts.length - 1] = '';
+    }
+
+    let rmj = romajiParts.join('');
+    if (rmj[rmj.length - 1] === '•') {
+      rmj = rmj.slice(0, -1);
+    }
+
+    return rmj;
+
   };
 
   return (


### PR DESCRIPTION
Changed a small bug within the Romaji to Kanji error that would add another • or remove the last character of a reading depending on the situation.

Still some other things I wish to change – but for the time being, this is okay.